### PR TITLE
pin  rabbit 3.8 to support env var -based configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
       retries: 5
       start_period: 30s
   rabbitmq:
-    image: rabbitmq:management
+    image: rabbitmq:3.8-management
     environment:
       - RABBITMQ_DEFAULT_USER=rabbitmq
       - RABBITMQ_DEFAULT_PASS=rabbitmq


### PR DESCRIPTION
Rabbit 3.9 deprecated using environment variables to pass username and password. this is causing our CI on CLI to break. This is a workaround while we fix the root cause.